### PR TITLE
Fix typo #161

### DIFF
--- a/Samples/1_Utilities/README.md
+++ b/Samples/1_Utilities/README.md
@@ -11,5 +11,5 @@ This sample enumerates the properties of the CUDA devices present in the system.
 This sample enumerates the properties of the CUDA devices present using CUDA Driver API calls
 
 ### [topologyQuery](./topologyQuery)
-A simple exemple on how to query the topology of a system with multiple GPU
+A simple example on how to query the topology of a system with multiple GPU
 


### PR DESCRIPTION
Fix typo in line 14 from "simple exemple" to simple "example"